### PR TITLE
Removed aws-sdk from package.json to fix error #1241 + minor README fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ A VueJs starter app integrated with [aws-amplify](https://github.com/aws/aws-amp
 
 ```bash
 $ git clone https://github.com/aws-samples/aws-amplify-vue.git
-$ cd aws-amplify-vue-sample
+$ cd aws-amplify-vue
 $ npm install
 ```
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   "dependencies": {
     "aws-amplify": "^1.1.4",
     "aws-amplify-vue": "^0.1.1",
-    "aws-sdk": "^2.209.0",
     "e": "0.0.4",
     "fsts": "^0.0.39",
     "vue": "^2.5.16",


### PR DESCRIPTION
*Issue #, if available:*
#1241
*Description of changes:*

Removed aws-sdk dependency from package.json to fix 'Storage, missing credentials in config' error when uploading to s3.

Changed 'cd aws-amplify-vue-sample' to the correct path after cloning the repo: 'cd was-amplify-vue' in README.md.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.