### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ A VueJs starter app integrated with [aws-amplify](https://github.com/aws/aws-amp
 
 ```bash
 $ git clone https://github.com/aws-samples/aws-amplify-vue.git
-$ cd aws-amplify-vue-sample
+$ cd aws-amplify-vue
 $ npm install
 ```
 
 2. Copy your `aws-exports` file into the src directory, or intialize a new [AWS Amplify CLI](https://github.com/aws-amplify/amplify-cli) project:
 
 ```bash
-$ npm install -g aws-amplify/cli
+$ npm install -g @aws-amplify/cli
 
 $ amplify init
 


### PR DESCRIPTION
Fixes to the installation procedure in the README.md:

1) After cloning the directory is  **aws-amplify-vue**  not **aws-amplify-vue-sample**

2) npm install -g aws-amplify/cli gives error because lacking of the @ in the package name, it should be **@aws-amplify/cli** insted of **aws-amplify/cli**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
