### PR TITLE
Updates aws-amplify/cli npm path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ npm install
 2. Copy your `aws-exports` file into the src directory, or intialize a new [AWS Amplify CLI](https://github.com/aws-amplify/amplify-cli) project:
 
 ```bash
-$ npm install -g aws-amplify/cli
+$ npm install -g @aws-amplify/cli
 
 $ amplify init
 


### PR DESCRIPTION
Needs `@` prefix in order to install properly, according to [aws-amplify/amplify-cli](https://github.com/aws-amplify/amplify-cli).

*Issue #, if available:*

*Description of changes:*

When trying to install without the `@` prefix, NPM fails. Could be a versioning issue on my machine, but the official docs for the `amplify-cli` uses the `@` prefix. This update makes both npm paths match.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
